### PR TITLE
Add Codecov integration to CI workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -29,3 +29,9 @@ jobs:
       - name: Test coverage
         run: covr::codecov(quiet = FALSE)
         shell: Rscript {0}
+      
+      - name: Upload coverage reports to Codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov


### PR DESCRIPTION
Which will post results of the `test-coverage` CI workflow (that runs covr) as a comment on PRs. I authorized codecov.io for the Arcadia-Science organization and followed the enable repo instructions