### PR TITLE
Change the aesthetic of the upset plots to match other plots in the package (`theme_classic()`) and allow palettes to be specified instead of defaulting to Set2

### DIFF
--- a/R/plot_gather.R
+++ b/R/plot_gather.R
@@ -116,7 +116,8 @@ plot_gather_upset <- function(upset_df, color_by_database = FALSE, gather_df = N
                                        ggplot2::scale_fill_manual(values=c('bars_color'='lightgrey'), guide='none') +
                                        ggplot2::theme_classic() +
                                        ggplot2::theme(axis.text.x = ggplot2::element_blank(),
-                                                      axis.ticks.x = ggplot2::element_blank()))
+                                                      axis.ticks.x = ggplot2::element_blank(),
+                                                      axis.title.x = ggplot2::element_blank()))
   )
   }
   if(color_by_database == T){
@@ -162,7 +163,8 @@ plot_gather_upset <- function(upset_df, color_by_database = FALSE, gather_df = N
                                          ggplot2::scale_fill_manual(values = palette) +
                                          ggplot2::theme_classic() +
                                          ggplot2::theme(axis.text.x = ggplot2::element_blank(),
-                                                        axis.ticks.x = ggplot2::element_blank()))
+                                                        axis.ticks.x = ggplot2::element_blank(),
+                                                        axis.title.x = ggplot2::element_blank()))
     )
   }
   return(upset_plt)

--- a/R/plot_gather.R
+++ b/R/plot_gather.R
@@ -95,6 +95,7 @@ from_gather_to_upset_df <- function(gather_df){
 #' @param upset_df An upset plot compliant data frame like that produced by from_gather_to_upset_df.
 #' @param color_by_database Boolean indicating whether to fill the upset plot instersection bar plot by the database the results came from. FALSE by default.
 #' @param gather_df Gather results passed to from_gather_to_upset_df to create the input data frame. NULL unless color_by_database is set to TRUE.
+#' @param palette Optional argument specifying the palette to use. Ignored unless color_by_database is set to TRUE. Defaults to RColorBrewer Set2 if color_by_database is set to TRUE and palette is not specified.
 #'
 #' @return A ComplexUpset plot.
 #' @export
@@ -105,14 +106,17 @@ from_gather_to_upset_df <- function(gather_df){
 #' \dontrun{
 #' plot_gather_upset(upset_df)
 #' }
-plot_gather_upset <- function(upset_df, color_by_database = FALSE, gather_df = NULL){
+plot_gather_upset <- function(upset_df, color_by_database = FALSE, gather_df = NULL, palette = NULL){
   if(color_by_database == F){
   upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df), set_sizes = F,
                                    base_annotations=list(
                                      '# genomes' = ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                                        text_colors=c(on_background='black', on_bar='black'),
                                                                                        mapping=ggplot2::aes(fill='bars_color')) +
-                                       ggplot2::scale_fill_manual(values=c('bars_color'='lightgrey'), guide='none'))
+                                       ggplot2::scale_fill_manual(values=c('bars_color'='lightgrey'), guide='none') +
+                                       ggplot2::theme_classic() +
+                                       ggplot2::theme(axis.text.x = ggplot2::element_blank(),
+                                                      axis.ticks.x = ggplot2::element_blank()))
   )
   }
   if(color_by_database == T){
@@ -144,13 +148,21 @@ plot_gather_upset <- function(upset_df, color_by_database = FALSE, gather_df = N
       dplyr::left_join(db_df, by = "genome_accession") %>%
       tibble::column_to_rownames("genome_accession")
 
-    upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df)[1:(ncol(upset_df)-1)],
-                                     themes=list(default=ggplot2::theme_classic()), set_sizes = F,
+    # create a palette if not user specified
+    if(is.null(palette)){
+      # if the user doesn't supply a palette, use Set2
+      palette <- c("#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3", "#A6D854", "#FFD92F", "#E5C494", "#B3B3B3")
+    }
+
+    upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df)[1:(ncol(upset_df)-1)], set_sizes = F,
                                      base_annotations = list(
                                        '# genomes' = ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                                       text_colors=c(on_background='black', on_bar='black'),
                                                                                       mapping=ggplot2::aes(fill = .data$database)) +
-                                         ggplot2::scale_fill_brewer(palette = "Set2"))
+                                         ggplot2::scale_fill_manual(values = palette) +
+                                         ggplot2::theme_classic() +
+                                         ggplot2::theme(axis.text.x = ggplot2::element_blank(),
+                                                        axis.ticks.x = ggplot2::element_blank()))
     )
   }
   return(upset_plt)

--- a/R/plot_gather.R
+++ b/R/plot_gather.R
@@ -144,7 +144,8 @@ plot_gather_upset <- function(upset_df, color_by_database = FALSE, gather_df = N
       dplyr::left_join(db_df, by = "genome_accession") %>%
       tibble::column_to_rownames("genome_accession")
 
-    upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df)[1:(ncol(upset_df)-1)], set_sizes = F,
+    upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df)[1:(ncol(upset_df)-1)],
+                                     themes=list(default=ggplot2::theme_classic()), set_sizes = F,
                                      base_annotations = list(
                                        '# genomes' = ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                                       text_colors=c(on_background='black', on_bar='black'),

--- a/R/plot_signatures.R
+++ b/R/plot_signatures.R
@@ -139,7 +139,8 @@ plot_signatures_upset <- function(upset_df){
                                        ggplot2::scale_fill_manual(values=c('bars_color'='lightgrey'), guide='none') +
                                        ggplot2::theme_classic() +
                                        ggplot2::theme(axis.text.x = ggplot2::element_blank(),
-                                                      axis.ticks.x = ggplot2::element_blank()))
+                                                      axis.ticks.x = ggplot2::element_blank(),
+                                                      axis.title.x = ggplot2::element_blank()))
   )
   return(upset_plt)
 }

--- a/R/plot_signatures.R
+++ b/R/plot_signatures.R
@@ -131,7 +131,8 @@ from_signatures_to_upset_df <- function(signatures_df){
 #' plot_signatures_upset()
 #' }
 plot_signatures_upset <- function(upset_df){
-  upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df), set_sizes = F,
+  upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df),
+                                   themes=list(default=ggplot2::theme_classic()), set_sizes = F,
                                    base_annotations=list(
                                      '# scaled k-mers'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                                        text_colors=c(on_background='black', on_bar='black'),

--- a/R/plot_signatures.R
+++ b/R/plot_signatures.R
@@ -131,13 +131,15 @@ from_signatures_to_upset_df <- function(signatures_df){
 #' plot_signatures_upset()
 #' }
 plot_signatures_upset <- function(upset_df){
-  upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df),
-                                   themes=list(default=ggplot2::theme_classic()), set_sizes = F,
+  upset_plt <- ComplexUpset::upset(upset_df, intersect = names(upset_df), set_sizes = F,
                                    base_annotations=list(
                                      '# scaled k-mers'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                                        text_colors=c(on_background='black', on_bar='black'),
                                                                                        mapping=ggplot2::aes(fill='bars_color')) +
-                                       ggplot2::scale_fill_manual(values=c('bars_color'='lightgrey'), guide='none'))
+                                       ggplot2::scale_fill_manual(values=c('bars_color'='lightgrey'), guide='none') +
+                                       ggplot2::theme_classic() +
+                                       ggplot2::theme(axis.text.x = ggplot2::element_blank(),
+                                                      axis.ticks.x = ggplot2::element_blank()))
   )
   return(upset_plt)
 }

--- a/R/plot_taxonomy_annotate.R
+++ b/R/plot_taxonomy_annotate.R
@@ -173,6 +173,7 @@ from_taxonomy_annotate_to_upset_inputs <- function(taxonomy_annotate_df,
 #'
 #' @param upset_inputs List of inputs produced by from_taxonomy_annotate_to_upset_inputs().
 #' @param fill Optional argument specifying which level of taxonomy to fill the upset plot intersections with. Only levels above upset_inputs$tax_glom_level are valid. Uses the Set2 palette so cannot visualize more than 8 levels.
+#' @param palette An optional character vector specifying the color palette to use. Ignored if fill is not set. Defaults to the colors in RColorBrewer Set2.
 #'
 #' @return A ComplexUpset plot
 #' @export
@@ -183,7 +184,7 @@ from_taxonomy_annotate_to_upset_inputs <- function(taxonomy_annotate_df,
 #' \dontrun{
 #' plot_taxonomy_annotate_upset()
 #' }
-plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL){
+plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL, palette = NULL){
   upset_df <- upset_inputs[[1]]
   taxonomy_annotate_df <- upset_inputs[[2]]
   tax_glom_level <- upset_inputs[[3]]
@@ -204,13 +205,19 @@ plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL){
       dplyr::left_join(taxonomy_annotate_df, by = "lineage") %>%
       tibble::column_to_rownames("lineage")
 
+    # create a palette if not user specified
+    if(is.null(palette)){
+      # if the user doesn't supply a palette, use Set2
+      palette <- c("#66C2A5", "#FC8D62", "#8DA0CB", "#E78AC3", "#A6D854", "#FFD92F", "#E5C494", "#B3B3B3")
+    }
+
     # plot the upset plot
     plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name), set_sizes = F,
                                base_annotations=list(
                                  '# lineages'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                               text_colors=c(on_background='black', on_bar='black'),
                                                                               mapping=ggplot2::aes(fill = .data$fill)) +
-                                   ggplot2::scale_fill_brewer(palette = "Set2") +
+                                   ggplot2::scale_fill_manual(values = palette) +
                                    ggplot2::labs(fill = fill))
     )
     return(plt)

--- a/R/plot_taxonomy_annotate.R
+++ b/R/plot_taxonomy_annotate.R
@@ -212,7 +212,8 @@ plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL, palette = NU
     }
 
     # plot the upset plot
-    plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name), set_sizes = F,
+    plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name),
+                               themes=list(default=ggplot2::theme_classic()), set_sizes = F,
                                base_annotations=list(
                                  '# lineages'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                               text_colors=c(on_background='black', on_bar='black'),
@@ -224,7 +225,8 @@ plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL, palette = NU
   }
 
   # plot the upset plot
-  plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name), set_sizes = F,
+  plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name),
+                             themes=list(default=ggplot2::theme_classic()), set_sizes = F,
                              base_annotations=list(
                                '# lineages'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                             text_colors=c(on_background='black', on_bar='black'))

--- a/R/plot_taxonomy_annotate.R
+++ b/R/plot_taxonomy_annotate.R
@@ -212,24 +212,28 @@ plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL, palette = NU
     }
 
     # plot the upset plot
-    plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name),
-                               themes=list(default=ggplot2::theme_classic()), set_sizes = F,
+    plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name), set_sizes = F,
                                base_annotations=list(
                                  '# lineages'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
                                                                               text_colors=c(on_background='black', on_bar='black'),
                                                                               mapping=ggplot2::aes(fill = .data$fill)) +
                                    ggplot2::scale_fill_manual(values = palette) +
-                                   ggplot2::labs(fill = fill))
+                                   ggplot2::labs(fill = fill) +
+                                   ggplot2::theme_classic() +
+                                   ggplot2::theme(axis.text.x = ggplot2::element_blank(),
+                                                  axis.ticks.x = ggplot2::element_blank()))
     )
     return(plt)
   }
 
   # plot the upset plot
-  plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name),
-                             themes=list(default=ggplot2::theme_classic()), set_sizes = F,
+  plt <- ComplexUpset::upset(upset_df, intersect = unique(upset_inputs[[2]]$query_name), set_sizes = F,
                              base_annotations=list(
                                '# lineages'=ComplexUpset::intersection_size(text=list(vjust=0.4, hjust=.05, angle=90),
-                                                                            text_colors=c(on_background='black', on_bar='black'))
+                                                                            text_colors=c(on_background='black', on_bar='black')) +
+                                 ggplot2::theme_classic() +
+                                 ggplot2::theme(axis.text.x = ggplot2::element_blank(),
+                                                axis.ticks.x = ggplot2::element_blank())
   ))
   return(plt)
 }

--- a/R/plot_taxonomy_annotate.R
+++ b/R/plot_taxonomy_annotate.R
@@ -221,7 +221,8 @@ plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL, palette = NU
                                    ggplot2::labs(fill = fill) +
                                    ggplot2::theme_classic() +
                                    ggplot2::theme(axis.text.x = ggplot2::element_blank(),
-                                                  axis.ticks.x = ggplot2::element_blank()))
+                                                  axis.ticks.x = ggplot2::element_blank(),
+                                                  axis.title.x = ggplot2::element_blank()))
     )
     return(plt)
   }
@@ -233,7 +234,8 @@ plot_taxonomy_annotate_upset <- function(upset_inputs, fill = NULL, palette = NU
                                                                             text_colors=c(on_background='black', on_bar='black')) +
                                  ggplot2::theme_classic() +
                                  ggplot2::theme(axis.text.x = ggplot2::element_blank(),
-                                                axis.ticks.x = ggplot2::element_blank())
+                                                axis.ticks.x = ggplot2::element_blank(),
+                                                axis.title.x = ggplot2::element_blank())
   ))
   return(plt)
 }

--- a/man/plot_gather_upset.Rd
+++ b/man/plot_gather_upset.Rd
@@ -4,7 +4,12 @@
 \alias{plot_gather_upset}
 \title{Visualize the intersection of genome accessions in sourmash gather results from many samples}
 \usage{
-plot_gather_upset(upset_df, color_by_database = FALSE, gather_df = NULL)
+plot_gather_upset(
+  upset_df,
+  color_by_database = FALSE,
+  gather_df = NULL,
+  palette = NULL
+)
 }
 \arguments{
 \item{upset_df}{An upset plot compliant data frame like that produced by from_gather_to_upset_df.}
@@ -12,6 +17,8 @@ plot_gather_upset(upset_df, color_by_database = FALSE, gather_df = NULL)
 \item{color_by_database}{Boolean indicating whether to fill the upset plot instersection bar plot by the database the results came from. FALSE by default.}
 
 \item{gather_df}{Gather results passed to from_gather_to_upset_df to create the input data frame. NULL unless color_by_database is set to TRUE.}
+
+\item{palette}{Optional argument specifying the palette to use. Ignored unless color_by_database is set to TRUE. Defaults to RColorBrewer Set2 if color_by_database is set to TRUE and palette is not specified.}
 }
 \value{
 A ComplexUpset plot.

--- a/man/plot_taxonomy_annotate_upset.Rd
+++ b/man/plot_taxonomy_annotate_upset.Rd
@@ -4,12 +4,14 @@
 \alias{plot_taxonomy_annotate_upset}
 \title{Visualize an upset plot of taxonomic lineage intersections between samples}
 \usage{
-plot_taxonomy_annotate_upset(upset_inputs, fill = NULL)
+plot_taxonomy_annotate_upset(upset_inputs, fill = NULL, palette = NULL)
 }
 \arguments{
 \item{upset_inputs}{List of inputs produced by from_taxonomy_annotate_to_upset_inputs().}
 
 \item{fill}{Optional argument specifying which level of taxonomy to fill the upset plot intersections with. Only levels above upset_inputs$tax_glom_level are valid. Uses the Set2 palette so cannot visualize more than 8 levels.}
+
+\item{palette}{An optional character vector specifying the color palette to use. Ignored if fill is not set. Defaults to the colors in RColorBrewer Set2.}
 }
 \value{
 A ComplexUpset plot


### PR DESCRIPTION
Addresses #55 and #57, which came up for me when I was making the plots for the sourmashconsumr pub.

Here's what an updated signatures upset plot would look like.

![image](https://user-images.githubusercontent.com/23057646/211067955-30c86064-2df1-4b38-83b1-75eea2de6159.png)


and taxonomy annotate when a user specifies the palette (don't @ me for how horrid this is...i just typed out the first colors that came to mind 😂 )
![image](https://user-images.githubusercontent.com/23057646/211067823-ee48d7c9-453e-47f7-b9bf-efbaf68b4a52.png)

