### PR TITLE
Initialize pkgdown and github action to automatically build a documentation site

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,6 @@
 ^data-raw$
 ^devdoc\.md$
 ^devenv\.yml$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,46 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 .DS_Store
 inst/doc
+docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,3 +40,4 @@ Imports:
 Depends: 
     R (>= 2.10)
 VignetteBuilder: knitr
+URL: https://arcadia-science.github.io/sourmashconsumr/

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,8 +28,8 @@ The sourmashconsumr package is still under active development.
 You can install the development version of sourmashconsumr from [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("Arcadia-Science/sourmashconsumr")
+# install.packages("remotes")
+remotes::install_github("Arcadia-Science/sourmashconsumr")
 ```
 
 Eventually, we hope to release sourmashconsumr on CRAN and to provide a conda-forge package. 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ You can install the development version of sourmashconsumr from
 [GitHub](https://github.com/) with:
 
 ``` r
-# install.packages("devtools")
-devtools::install_github("Arcadia-Science/sourmashconsumr")
+# install.packages("remotes")
+remotes::install_github("Arcadia-Science/sourmashconsumr")
 ```
 
 Eventually, we hope to release sourmashconsumr on CRAN and to provide a

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,4 @@
+url: https://arcadia-science.github.io/sourmashconsumr/
+template:
+  bootstrap: 5
+

--- a/devdoc.md
+++ b/devdoc.md
@@ -146,6 +146,25 @@ The html file should not be pushed to GitHub.
 The README.md is created from a README.Rmd file.
 To edit the README.md file, make changes to the README.Rmd file and knit it.
 
+### pkgdown package documentation site
+
+sourmashconsumr uses [pkgdown](https://pkgdown.r-lib.org/index.html) to build the sourmashconsumr documentation.
+To build the package documentation site locally, you can use:
+```
+usethis::use_pkgdown()
+pkgdown::build_site()
+```
+
+You shouldn't have to do this next part, but to set up GitHub Actions so the site would be automatically built, we used the following code:
+```
+# set up git credentials
+usethis::gh_token_help()
+usethis::create_github_token()
+gitcreds::gitcreds_set()
+# use gh-pages and github actions to build site
+usethis::use_pkgdown_github_pages()
+```
+
 ### Checking all the things
 
 After making changes, you should run `devtools::check()` locally to make sure all tests pass, documentation is updated, and there are no other failures or warning in the local build process.

--- a/devenv.yml
+++ b/devenv.yml
@@ -8,6 +8,7 @@ dependencies:
    - r-testthat=3.1.6
    - r-usethis=2.1.6
    - r-roxygen2=7.2.1
+   - r-pkdown=2.0.7
    - r-stringr=1.5.0
    - r-complexupset=1.3.3
    - r-dplyr=1.0.10


### PR DESCRIPTION
site will live at https://arcadia-science.github.io/sourmashconsumr/

This PR follows the pkgdown documentation: https://pkgdown.r-lib.org/articles/pkgdown.html

I think this will have to be merged for the site to go live? this is my first time doing this and the documentation on pkgdown isn't super clear, but i think all the things are done to enable the site to render once this is merged.